### PR TITLE
Make Repr::new() infallible

### DIFF
--- a/canon/Cargo.toml
+++ b/canon/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "canonical"
-version = "0.2.1"
+version = "0.3.0"
 authors = ["Kristoffer Ström <kristoffer@dusk.network>"]
 edition = "2018"
 readme = "README.md"
@@ -15,10 +15,10 @@ arrayvec = { version = "0.5", default-features = false }
 arbitrary = { version = "0.3", features = ["derive"], optional = true }
 
 [dev-dependencies]
-canonical_host = { path = "../canon_host", version = "0.2.1" }
-canonical_derive = { path = "../canon_derive", version = "0.2.1" }
-canonical_collections = { path = "../canon_collections", version = "0.2.1" }
-canonical_fuzz = { path = "../canon_fuzz", version = "0.2.1" }
+canonical_host = { path = "../canon_host", version = "0.3.0" }
+canonical_derive = { path = "../canon_derive", version = "0.3.0" }
+canonical_collections = { path = "../canon_collections", version = "0.3.0" }
+canonical_fuzz = { path = "../canon_fuzz", version = "0.3.0" }
 
 [features]
 host = ["blake2b_simd/std", "arbitrary"]

--- a/canon/src/repr_host.rs
+++ b/canon/src/repr_host.rs
@@ -131,11 +131,11 @@ where
     T: Canon<S> + Clone,
 {
     /// Construct a new `Repr` from value `t`
-    pub fn new(t: T) -> Result<Self, S::Error> {
-        Ok(Repr::Value {
+    pub fn new(t: T) -> Self {
+        Repr::Value {
             rc: Rc::new(t),
             cached_ident: RefCell::new(None),
-        })
+        }
     }
 
     /// Returns the value behind the `Repr`

--- a/canon/src/repr_hosted.rs
+++ b/canon/src/repr_hosted.rs
@@ -90,8 +90,8 @@ where
         // can we inline the value?
         if len <= buffer.as_ref().len() {
             let mut sink = ByteSink::new(buffer.as_mut(), store.clone());
-            // TODO: Handle this as a host error
-            t.write(&mut sink).unwrap();
+            t.write(&mut sink)
+                .expect("Pre-checked buffer of sufficient length");
 
             Repr::Inline {
                 bytes: buffer,
@@ -99,8 +99,10 @@ where
                 _marker: PhantomData,
             }
         } else {
-            // TODO: Handle errors in Host
-            let id = store.put(&t).unwrap();
+            // Here we assume that we can put something in the host.
+            // If this actually returns an error from the BridgeStore,
+            // we panic and let the host deal with it.
+            let id = store.put(&t).expect("BridgeStore should never fail");
             Repr::Ident(id)
         }
     }

--- a/canon/src/repr_hosted.rs
+++ b/canon/src/repr_hosted.rs
@@ -80,7 +80,7 @@ where
     T: Canon<S>,
 {
     /// Construct a new `Repr` from value `t`
-    pub fn new(t: T) -> Result<Self, S::Error> {
+    pub fn new(t: T) -> Self {
         // The Default store is always the same in hosted environments
         let store = S::default();
 
@@ -90,16 +90,18 @@ where
         // can we inline the value?
         if len <= buffer.as_ref().len() {
             let mut sink = ByteSink::new(buffer.as_mut(), store.clone());
-            t.write(&mut sink)?;
+            // TODO: Handle this as a host error
+            t.write(&mut sink).unwrap();
 
-            Ok(Repr::Inline {
+            Repr::Inline {
                 bytes: buffer,
                 len: len as u8,
                 _marker: PhantomData,
-            })
+            }
         } else {
-            let id = store.put(&t)?;
-            Ok(Repr::Ident(id))
+            // TODO: Handle errors in Host
+            let id = store.put(&t).unwrap();
+            Repr::Ident(id)
         }
     }
 

--- a/canon/tests/handle.rs
+++ b/canon/tests/handle.rs
@@ -7,7 +7,7 @@ use canonical_host::MemStore;
 #[test]
 fn zero_sized_reprs() {
     let store = MemStore::new();
-    let repr = Repr::new(()).unwrap();
+    let repr = Repr::new(());
 
     let id = store.put(&repr).unwrap();
 

--- a/canon/tests/identifier.rs
+++ b/canon/tests/identifier.rs
@@ -25,7 +25,7 @@ fn identifier_stack() {
     let n = 8;
 
     for i in 0u64..n {
-        stack.push(i).unwrap();
+        stack.push(i);
     }
 
     let id_a: Id32 = MemStore::ident(&stack);

--- a/canon_collections/Cargo.toml
+++ b/canon_collections/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "canonical_collections"
-version = "0.2.1"
+version = "0.3.0"
 authors = ["Kristoffer Ström <kristoffer@dusk.network>"]
 edition = "2018"
 readme = "README.md"
@@ -10,11 +10,11 @@ description = "Data structures for use with Canonical"
 license = "MPL-2.0"
 
 [dependencies]
-canonical_derive = { path = "../canon_derive", version = "0.2.1" }
-canonical = { path = "../canon", version = "0.2.1" }
+canonical_derive = { path = "../canon_derive", version = "0.3.0" }
+canonical = { path = "../canon", version = "0.3.0" }
 
 [dev-dependencies]
-canonical_host = { path = "../canon_host", version = "0.2.1" }
+canonical_host = { path = "../canon_host", version = "0.3.0" }
 
 [features]
 host = ["canonical/host"]

--- a/canon_collections/src/stack.rs
+++ b/canon_collections/src/stack.rs
@@ -26,13 +26,12 @@ where
     }
 
     /// Pushes a value to the stack
-    pub fn push(&mut self, t: T) -> Result<(), S::Error> {
+    pub fn push(&mut self, t: T) {
         let root = core::mem::replace(self, Stack::Empty);
         *self = Stack::Node {
             value: t,
-            prev: Repr::<_, S>::new(root)?,
+            prev: Repr::<_, S>::new(root),
         };
-        Ok(())
     }
 
     /// Pops a value from the stack, if any and returns it
@@ -62,7 +61,7 @@ mod test {
         let mut list = Stack::<_, MemStore>::new();
 
         for i in 0..n {
-            list.push(i).unwrap();
+            list.push(i);
         }
 
         for i in 0..n {
@@ -84,7 +83,7 @@ mod test {
         let mut list = Stack::new();
 
         for i in 0..n {
-            list.push(i).unwrap()
+            list.push(i)
         }
 
         let id = store.put(&list).unwrap();
@@ -115,7 +114,7 @@ mod test {
             let mut list = Stack::new();
 
             for i in 0..n {
-                list.push(tuple(i)).unwrap();
+                list.push(tuple(i));
             }
 
             let id = store.put(&list).unwrap();

--- a/canon_derive/Cargo.toml
+++ b/canon_derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "canonical_derive"
-version = "0.2.1"
+version = "0.3.0"
 authors = ["Kristoffer Ström <kristoffer@dusk.network>"]
 edition = "2018"
 readme = "README.md"
@@ -13,7 +13,7 @@ license = "MPL-2.0"
 proc-macro2 = "1.0.10"
 quote = "1.0.3"
 syn = { version = "1.0.17" }
-canonical = { path = "../canon", version = "0.2.1" }
+canonical = { path = "../canon", version = "0.3.0" }
 
 [lib]
 proc-macro = true

--- a/canon_fuzz/Cargo.toml
+++ b/canon_fuzz/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "canonical_fuzz"
-version = "0.2.1"
+version = "0.3.0"
 authors = ["Kristoffer Ström <kristoffer@dusk.network>"]
 edition = "2018"
 repository = "https://github.com/dusk-network/canonical/canon_fuzz"
@@ -8,6 +8,6 @@ description = "Fuzzing helpers for Canonical encodings"
 license = "MPL-2.0"
 
 [dependencies]
-canonical = { path = "../canon" , features = ["host"], version = "0.2.1" }
-canonical_host = { path = "../canon_host", version = "0.2.1" }
+canonical = { path = "../canon" , features = ["host"], version = "0.3.0" }
+canonical_host = { path = "../canon_host", version = "0.3.0" }
 arbitrary = { version = "0.3" }

--- a/canon_host/Cargo.toml
+++ b/canon_host/Cargo.toml
@@ -2,7 +2,7 @@
 authors = ["Kristoffer Ström <kristoffer@dusk.network>"]
 edition = "2018"
 name = "canonical_host"
-version = "0.2.1"
+version = "0.3.0"
 readme = "README.md"
 repository = "https://github.com/dusk-network/canonical/canon_host"
 keywords = ["canon", "serialisation", "no_std", "ffi", "database"]
@@ -13,8 +13,8 @@ license = "MPL-2.0"
 lazy_static = "1.4"
 parking_lot = "0.11"
 wasmi = "0.6.0"
-canonical = { path = "../canon", version = "0.2.1" }
-canonical_derive = { path = "../canon_derive", version = "0.2.1" }
+canonical = { path = "../canon", version = "0.3.0" }
+canonical_derive = { path = "../canon_derive", version = "0.3.0" }
 
 [dev-dependencies]
 counter = { path = "examples/counter", features = ["host"], version = "0.1.0" }

--- a/canon_host/examples/storage/src/lib.rs
+++ b/canon_host/examples/storage/src/lib.rs
@@ -28,7 +28,7 @@ mod hosted {
     type BS = BridgeStore<Id32>;
 
     impl Storage<BS> {
-        pub fn push(&mut self, value: u8) -> Result<(), <BS as Store>::Error> {
+        pub fn push(&mut self, value: u8) {
             self.0.push(value)
         }
 
@@ -52,7 +52,6 @@ mod hosted {
             // push
             0xaaa => {
                 let t: u8 = Canon::<BS>::read(&mut source)?;
-
                 let res = slf.push(t);
                 let mut sink = ByteSink::new(&mut bytes[..], store.clone());
                 // return new state
@@ -109,9 +108,7 @@ mod host {
     type TransactionIndex = u16;
 
     impl<S: Store> Storage<S> {
-        pub fn push(
-            i: u8,
-        ) -> Transaction<(TransactionIndex, u8), Result<(), S::Error>> {
+        pub fn push(i: u8) -> Transaction<(TransactionIndex, u8), ()> {
             Transaction::new((0xaaa, i))
         }
 

--- a/canon_host/tests/storage_test.rs
+++ b/canon_host/tests/storage_test.rs
@@ -22,7 +22,6 @@ fn storage() {
         cast.transact(&Storage::<Mem>::push(val), store.clone())
             .unwrap()
             .unwrap()
-            .unwrap()
     }
 
     // pop n values


### PR DESCRIPTION
This greatly simplifies code that need to create new Reprs.

In the host case, we can always allocate.
In the hosted case, we can assume that our allocation works, and throw any potential error as a panic for he host.