### PR TITLE
Use custom Cow without alloc

### DIFF
--- a/canon/src/cow.rs
+++ b/canon/src/cow.rs
@@ -1,7 +1,16 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) DUSK NETWORK. All rights reserved.
+
 use core::ops::{Deref, DerefMut};
 
+/// No-std compatible alternative to `std::Cow`
 pub enum Cow<'a, T> {
+    /// An owned instance of `T`
     Owned(T),
+    /// A borrowed instance of `T`
     Borrowed(&'a T),
 }
 

--- a/canon/src/cow.rs
+++ b/canon/src/cow.rs
@@ -1,0 +1,33 @@
+use core::ops::{Deref, DerefMut};
+
+pub enum Cow<'a, T> {
+    Owned(T),
+    Borrowed(&'a T),
+}
+
+impl<'a, T> Deref for Cow<'a, T> {
+    type Target = T;
+
+    fn deref(&self) -> &T {
+        match self {
+            Cow::Borrowed(t) => t,
+            Cow::Owned(t) => &t,
+        }
+    }
+}
+
+impl<'a, T> DerefMut for Cow<'a, T>
+where
+    T: Clone,
+{
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        if let Cow::Borrowed(t) = self {
+            *self = Cow::Owned(t.clone())
+        }
+        if let Cow::Owned(ref mut t) = self {
+            t
+        } else {
+            unreachable!()
+        }
+    }
+}

--- a/canon/src/lib.rs
+++ b/canon/src/lib.rs
@@ -24,12 +24,14 @@ mod repr_host;
 #[cfg(feature = "host")]
 pub use repr_host::{Repr, ValMut};
 
+mod cow;
 mod dry_sink;
 mod id;
 mod implementations;
 mod store;
 
 pub use canon::{Canon, InvalidEncoding};
+pub use cow::Cow;
 pub use dry_sink::DrySink;
 pub use id::Id32;
 pub use store::{ByteSink, ByteSource, IdBuilder, Ident, Sink, Source, Store};

--- a/canon/src/repr_host.rs
+++ b/canon/src/repr_host.rs
@@ -4,13 +4,14 @@
 //
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
-use std::borrow::Cow;
+// Here in feature `host` we can use std
 use std::cell::RefCell;
 use std::ops::{Deref, DerefMut};
 use std::rc::Rc;
 
 use arbitrary::{self, Arbitrary};
 
+use crate::cow::Cow;
 use crate::{Canon, Sink, Source, Store};
 
 const IDENT_TAG: u8 = 0xff;


### PR DESCRIPTION
Since Cow does depend on `alloc`, we instead define our own.

Resolves: #30 