### PR TITLE
Switch to nightly-2020-10-25 toolchain for fmt

### DIFF
--- a/.github/workflows/dusk_ci.yml
+++ b/.github/workflows/dusk_ci.yml
@@ -51,10 +51,11 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: nightly
+          toolchain: nightly-2020-10-25
           override: true
       - run: rustup component add rustfmt
       - uses: actions-rs/cargo@v1
         with:
           command: fmt
           args: --all -- --check
+


### PR DESCRIPTION
Since rustfmt is kinda broken depending on the nightly release
we're on, it's better for now to have the CI with a fixed toolchain
used for the rustfmt tests.

Therefore nightly-2020-10-25 was the choosen one.