### PR TITLE
Enable MemoryRef as ExternalResolver inner attribute

### DIFF
--- a/canon_host/src/lib.rs
+++ b/canon_host/src/lib.rs
@@ -18,4 +18,6 @@ mod remote;
 pub use remote::Remote;
 
 mod wasm;
-pub use wasm::{ExternalsResolver, Query, Signal, Transaction, Wasm};
+pub use wasm::{
+    ExternalsResolver, MemoryHolder, Query, Signal, Transaction, Wasm,
+};

--- a/canon_host/src/wasm.rs
+++ b/canon_host/src/wasm.rs
@@ -29,7 +29,7 @@ pub trait MemoryHolder {
     /// Set MemoryRef
     fn set_memory(&mut self, memory: wasmi::MemoryRef);
     /// Get access to the internal [`MemoryRef`]
-    fn access_memory(&self) -> Result<wasmi::MemoryRef, wasmi::Trap>;
+    fn memory(&self) -> Result<wasmi::MemoryRef, wasmi::Trap>;
 }
 
 /// Super trait that requires both wasmi::Externals and
@@ -39,7 +39,7 @@ pub trait ExternalsResolver:
 {
 }
 
-impl<'a, T: wasmi::Externals + wasmi::ModuleImportResolver + MemoryHolder>
+impl<T: wasmi::Externals + wasmi::ModuleImportResolver + MemoryHolder>
     ExternalsResolver for T
 {
 }
@@ -337,7 +337,7 @@ where
     }
 
     /// Perform the provided query in the wasm module
-    pub fn query<'a, A, R, E>(
+    pub fn query<A, R, E>(
         &self,
         query: &Query<A, R>,
         store: S,

--- a/canon_host/src/wasm.rs
+++ b/canon_host/src/wasm.rs
@@ -28,6 +28,8 @@ pub enum Signal {
 pub trait MemoryHolder {
     /// Set MemoryRef
     fn set_memory(&mut self, memory: wasmi::MemoryRef);
+    /// Get access to the internal [`MemoryRef`]
+    fn access_memory(&self) -> Result<wasmi::MemoryRef, wasmi::Trap>;
 }
 
 /// Super trait that requires both wasmi::Externals and

--- a/canon_host/src/wasm.rs
+++ b/canon_host/src/wasm.rs
@@ -27,7 +27,7 @@ pub enum Signal {
 /// Trait required to set a MemoryRef
 pub trait MemoryHolder {
     /// Set MemoryRef
-    fn set_memory<'a>(&mut self, memory: &'a wasmi::MemoryRef);
+    fn set_memory(&mut self, memory: wasmi::MemoryRef);
 }
 
 /// Super trait that requires both wasmi::Externals and
@@ -37,7 +37,7 @@ pub trait ExternalsResolver:
 {
 }
 
-impl<T: wasmi::Externals + wasmi::ModuleImportResolver + MemoryHolder>
+impl<'a, T: wasmi::Externals + wasmi::ModuleImportResolver + MemoryHolder>
     ExternalsResolver for T
 {
 }
@@ -335,7 +335,7 @@ where
     }
 
     /// Perform the provided query in the wasm module
-    pub fn query<A, R, E>(
+    pub fn query<'a, A, R, E>(
         &self,
         query: &Query<A, R>,
         store: S,
@@ -366,7 +366,7 @@ where
                     Canon::<S>::write(query.args(), &mut sink)
                 })?;
                 let mut resolver = resolver;
-                resolver.set_memory(&memref);
+                resolver.set_memory(memref.clone());
                 let mut externals = Externals::new(&store, &memref, resolver);
 
                 // Perform the query call

--- a/canon_host/src/wasm.rs
+++ b/canon_host/src/wasm.rs
@@ -24,15 +24,21 @@ pub enum Signal {
     Error(String),
 }
 
+/// Trait required to set a MemoryRef
+pub trait MemoryHolder {
+    /// Set MemoryRef
+    fn set_memory<'a>(&mut self, memory: &'a wasmi::MemoryRef);
+}
+
 /// Super trait that requires both wasmi::Externals and
 /// wasmi::ModuleImportResolver
 pub trait ExternalsResolver:
-    wasmi::Externals + wasmi::ModuleImportResolver
+    wasmi::Externals + wasmi::ModuleImportResolver + MemoryHolder
 {
 }
 
-impl<T: wasmi::Externals + wasmi::ModuleImportResolver> ExternalsResolver
-    for T
+impl<T: wasmi::Externals + wasmi::ModuleImportResolver + MemoryHolder>
+    ExternalsResolver for T
 {
 }
 
@@ -359,7 +365,8 @@ where
                     Canon::<S>::write(&self.state, &mut sink)?;
                     Canon::<S>::write(query.args(), &mut sink)
                 })?;
-
+                let mut resolver = resolver;
+                resolver.set_memory(&memref);
                 let mut externals = Externals::new(&store, &memref, resolver);
 
                 // Perform the query call

--- a/canon_host/src/wasm.rs
+++ b/canon_host/src/wasm.rs
@@ -420,7 +420,8 @@ where
                     // then the arguments, as bytes
                     Canon::<S>::write(transaction.args(), &mut sink)
                 })?;
-
+                let mut resolver = resolver;
+                resolver.set_memory(memref.clone());
                 let mut externals = Externals::new(&store, &memref, resolver);
 
                 instance.invoke_export(

--- a/module_examples/modules/resolver/src/lib.rs
+++ b/module_examples/modules/resolver/src/lib.rs
@@ -28,7 +28,7 @@ impl Counter {
 #[cfg(not(feature = "host"))]
 mod hosted {
     extern "C" {
-        fn host_function(n: i32) -> i32;
+        fn host_function(n: u8) -> i32;
     }
 
     use super::*;
@@ -45,7 +45,7 @@ mod hosted {
         }
 
         pub fn adjust(&mut self, by: i32) {
-            self.value += unsafe { host_function(by) };
+            self.value += unsafe { host_function(by.to_le_bytes()[0]) };
         }
     }
 

--- a/module_examples/modules/resolver/src/lib.rs
+++ b/module_examples/modules/resolver/src/lib.rs
@@ -28,7 +28,7 @@ impl Counter {
 #[cfg(not(feature = "host"))]
 mod hosted {
     extern "C" {
-        fn host_function(n: u8) -> i32;
+        fn host_function(n: &u8) -> i32;
     }
 
     use super::*;
@@ -45,7 +45,7 @@ mod hosted {
         }
 
         pub fn adjust(&mut self, by: i32) {
-            self.value += unsafe { host_function(by.to_le_bytes()[0]) };
+            self.value += unsafe { host_function(&by.to_le_bytes()[0]) };
         }
     }
 

--- a/module_examples/tests/common.rs
+++ b/module_examples/tests/common.rs
@@ -36,7 +36,7 @@ impl ModuleImportResolver for HostExternals {
 
 impl MemoryHolder for HostExternals {
     fn set_memory(&mut self, _memory: wasmi::MemoryRef) {}
-    fn access_memory(&self) -> Result<wasmi::MemoryRef, wasmi::Trap> {
+    fn memory(&self) -> Result<wasmi::MemoryRef, wasmi::Trap> {
         Err(Trap::new(wasmi::TrapKind::ElemUninitialized))
     }
 }

--- a/module_examples/tests/common.rs
+++ b/module_examples/tests/common.rs
@@ -9,6 +9,8 @@ use wasmi::{
     Signature, Trap,
 };
 
+use canonical_host::MemoryHolder;
+
 #[derive(Clone, Copy)]
 pub struct HostExternals {}
 
@@ -30,6 +32,10 @@ impl ModuleImportResolver for HostExternals {
     ) -> Result<FuncRef, Error> {
         unimplemented!();
     }
+}
+
+impl MemoryHolder for HostExternals {
+    fn set_memory(&mut self, _memory: &wasmi::MemoryRef) {}
 }
 
 pub fn no_externals() -> HostExternals {

--- a/module_examples/tests/common.rs
+++ b/module_examples/tests/common.rs
@@ -35,7 +35,7 @@ impl ModuleImportResolver for HostExternals {
 }
 
 impl MemoryHolder for HostExternals {
-    fn set_memory(&mut self, _memory: &wasmi::MemoryRef) {}
+    fn set_memory(&mut self, _memory: wasmi::MemoryRef) {}
 }
 
 pub fn no_externals() -> HostExternals {

--- a/module_examples/tests/common.rs
+++ b/module_examples/tests/common.rs
@@ -36,6 +36,9 @@ impl ModuleImportResolver for HostExternals {
 
 impl MemoryHolder for HostExternals {
     fn set_memory(&mut self, _memory: wasmi::MemoryRef) {}
+    fn access_memory(&self) -> Result<wasmi::MemoryRef, wasmi::Trap> {
+        Err(Trap::new(wasmi::TrapKind::ElemUninitialized))
+    }
 }
 
 pub fn no_externals() -> HostExternals {

--- a/module_examples/tests/resolver_test.rs
+++ b/module_examples/tests/resolver_test.rs
@@ -24,7 +24,7 @@ impl MemoryHolder for HostExternals {
     fn set_memory(&mut self, memory: wasmi::MemoryRef) {
         self.memory = Some(memory);
     }
-    fn access_memory(&self) -> Result<wasmi::MemoryRef, wasmi::Trap> {
+    fn memory(&self) -> Result<wasmi::MemoryRef, wasmi::Trap> {
         self.memory
             .to_owned()
             .ok_or_else(|| Trap::new(TrapKind::ElemUninitialized))
@@ -43,7 +43,7 @@ impl Externals for HostExternals {
             FUNC_INDEX => {
                 if let [wasmi::RuntimeValue::I32(ofs)] = args.as_ref()[..] {
                     let ofs = ofs as usize;
-                    self.access_memory()?.with_direct_access_mut(|mem| {
+                    self.memory()?.with_direct_access_mut(|mem| {
                         let mut bytes = [0u8; 4];
                         bytes.copy_from_slice(&mem[ofs..ofs + 4]);
                         let result = i32::from_le_bytes(bytes);

--- a/module_examples/tests/resolver_test.rs
+++ b/module_examples/tests/resolver_test.rs
@@ -13,12 +13,22 @@ use wasmi::{
     Signature, Trap,
 };
 
+use canonical_host::MemoryHolder;
+
 #[derive(Clone, Copy)]
-struct HostExternals {}
+struct HostExternals<'a> {
+    memory: Option<&'a wasmi::MemoryRef>,
+}
+
+impl<'a> MemoryHolder for HostExternals<'a> {
+    fn set_memory(&mut self, memory: &wasmi::MemoryRef) {
+        self.memory = Some(memory)
+    }
+}
 
 const FUNC_INDEX: usize = 100;
 
-impl Externals for HostExternals {
+impl<'a> Externals for HostExternals<'a> {
     fn invoke_index(
         &mut self,
         index: usize,
@@ -36,7 +46,7 @@ impl Externals for HostExternals {
     }
 }
 
-impl ModuleImportResolver for HostExternals {
+impl<'a> ModuleImportResolver for HostExternals<'a> {
     fn resolve_func(
         &self,
         field_name: &str,
@@ -61,7 +71,7 @@ impl ModuleImportResolver for HostExternals {
 
 #[test]
 fn query() {
-    let host_externals = HostExternals {};
+    let host_externals = HostExternals { memory: None };
 
     let store = MemStore::new();
     let wasm_counter = Wasm::new(
@@ -83,7 +93,7 @@ fn query() {
 
 #[test]
 fn resolver_transaction() {
-    let host_externals = HostExternals {};
+    let host_externals = HostExternals { memory: None };
 
     let store = MemStore::new();
     let wasm_counter = Wasm::new(

--- a/module_examples/tests/resolver_test.rs
+++ b/module_examples/tests/resolver_test.rs
@@ -15,20 +15,20 @@ use wasmi::{
 
 use canonical_host::MemoryHolder;
 
-#[derive(Clone, Copy)]
-struct HostExternals<'a> {
-    memory: Option<&'a wasmi::MemoryRef>,
+#[derive(Clone)]
+struct HostExternals {
+    memory: Option<wasmi::MemoryRef>,
 }
 
-impl<'a> MemoryHolder for HostExternals<'a> {
-    fn set_memory(&mut self, memory: &wasmi::MemoryRef) {
+impl MemoryHolder for HostExternals {
+    fn set_memory(&mut self, memory: wasmi::MemoryRef) {
         self.memory = Some(memory)
     }
 }
 
 const FUNC_INDEX: usize = 100;
 
-impl<'a> Externals for HostExternals<'a> {
+impl Externals for HostExternals {
     fn invoke_index(
         &mut self,
         index: usize,
@@ -46,7 +46,7 @@ impl<'a> Externals for HostExternals<'a> {
     }
 }
 
-impl<'a> ModuleImportResolver for HostExternals<'a> {
+impl<'a> ModuleImportResolver for HostExternals {
     fn resolve_func(
         &self,
         field_name: &str,
@@ -103,7 +103,7 @@ fn resolver_transaction() {
     let mut remote = Remote::new(wasm_counter, &store).unwrap();
 
     let mut cast = remote.cast_mut::<Wasm<Counter, MemStore>>().unwrap();
-    cast.transact(&Counter::adjust(-10), store.clone(), host_externals)
+    cast.transact(&Counter::adjust(-10), store.clone(), host_externals.clone())
         .unwrap();
     cast.commit().unwrap();
 

--- a/module_examples/tests/resolver_test.rs
+++ b/module_examples/tests/resolver_test.rs
@@ -15,7 +15,7 @@ use wasmi::{
 
 use canonical_host::MemoryHolder;
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 struct HostExternals {
     memory: Option<wasmi::MemoryRef>,
 }
@@ -23,7 +23,6 @@ struct HostExternals {
 impl MemoryHolder for HostExternals {
     fn set_memory(&mut self, memory: wasmi::MemoryRef) {
         self.memory = Some(memory);
-        //
     }
 }
 
@@ -38,7 +37,6 @@ impl Externals for HostExternals {
         match index {
             FUNC_INDEX => {
                 if let [wasmi::RuntimeValue::I32(ofs)] = args.as_ref()[..] {
-                    panic!("{:?}", self.memory);
                     let ofs = ofs as usize;
                     self.memory
                         .as_ref()
@@ -48,7 +46,7 @@ impl Externals for HostExternals {
                             let mut bytes = [0u8; 4];
                             bytes.copy_from_slice(&mem[ofs..ofs + 4]);
                             let result = i32::from_le_bytes(bytes);
-                            Ok(Some(RuntimeValue::I32(result)))
+                            Ok(Some(RuntimeValue::I32(result as i32)))
                         })
                 } else {
                     todo!("error out for wrong argument types")
@@ -126,6 +124,6 @@ fn resolver_transaction() {
             .unwrap()
             .query(&Counter::read_value(), store, host_externals)
             .unwrap(),
-        87
+        89
     );
 }


### PR DESCRIPTION
This continues the work started in #54 by @ZER0 taking a slightly different direction in respect to the lifetime issues he was experiencing.

The thing is that MemRef is defined as:
```rust
pub struct MemoryRef(Rc<MemoryInstance>);
```

And at the same time, `MemoryInstance` looks like:
```rust
pub struct MemoryInstance {
    /// Memory limits.
    limits: ResizableLimits,
    /// Linear memory buffer with lazy allocation.
    buffer: RefCell<ByteBuf>,
    initial: Pages,
    current_size: Cell<usize>,
    maximum: Option<Pages>,
}
```

The structures mostly contain references and no heavy
data structures directly. And also, counting that we
have the `Rc` I think we should clone the structure,
instead of try to play sneaky with the lifetimes.

Since at the end I don't think it will make a big
difference in terms of performance.

Closes #55