### PR TITLE
Bridge feat removal & support for [T;33]

### DIFF
--- a/canon/Cargo.toml
+++ b/canon/Cargo.toml
@@ -11,7 +11,7 @@ license = "MPL-2.0"
 
 [dependencies]
 blake2b_simd = { version = "0.3", default-features = false }
-arrayvec = { version = "0.5", default-features = false }
+arrayvec = { version = "0.5", default-features = false, features = ["array-sizes-33-128"] }
 arbitrary = { version = "0.3", features = ["derive"], optional = true }
 cfg-if = "1.0.0"
 

--- a/canon/Cargo.toml
+++ b/canon/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "canonical"
-version = "0.4.2"
+version = "0.4.3"
 authors = ["Kristoffer Ström <kristoffer@dusk.network>"]
 edition = "2018"
 readme = "README.md"

--- a/canon/src/implementations.rs
+++ b/canon/src/implementations.rs
@@ -259,7 +259,7 @@ macro_rules! array {
             }
 
             fn read(source: &mut impl Source<S>) -> Result<Self, S::Error> {
-                let mut array = arrayvec::ArrayVec::new();
+                let mut array = arrayvec::ArrayVec::<[T; $n]>::new();
 
                 for _ in 0..$n {
                     array.push(T::read(source)?);
@@ -282,7 +282,6 @@ macro_rules! array {
     };
 }
 
-array!(0);
 array!(1);
 array!(2);
 array!(3);
@@ -315,6 +314,7 @@ array!(29);
 array!(30);
 array!(31);
 array!(32);
+array!(33);
 
 #[cfg(feature = "host")]
 mod std_impls {

--- a/canon/src/lib.rs
+++ b/canon/src/lib.rs
@@ -18,10 +18,8 @@ mod implementations;
 mod repr;
 mod store;
 
-#[cfg(not(feature = "host"))]
 mod bridge;
 
-#[cfg(not(feature = "host"))]
 pub use bridge::BridgeStore;
 
 pub use canon::{Canon, InvalidEncoding};


### PR DESCRIPTION
Once the work on https://github.com/dusk-network/rusk/pull/146 was started, we noticed we will need to serialize through canonical arrays of 33 bytes. This was not possible if we don't use the `"array-sizes-33-128"` feature of `ArrayVec`.

Also, the `cfg(not..` gates have been removed from `lib.rs` since they were causing compilation errors due to `cargo` getting confused.