### PR TITLE
Bump canon_host to v0.4.3

### DIFF
--- a/canon_host/Cargo.toml
+++ b/canon_host/Cargo.toml
@@ -2,7 +2,7 @@
 authors = ["Kristoffer Ström <kristoffer@dusk.network>"]
 edition = "2018"
 name = "canonical_host"
-version = "0.4.2"
+version = "0.4.3"
 readme = "README.md"
 repository = "https://github.com/dusk-network/canonical/canon_host"
 keywords = ["canon", "serialisation", "no_std", "ffi", "database"]


### PR DESCRIPTION
Closes #60 by releasing the latest changes in `canon_host` which haven't been released yet.