### PR TITLE
Canon for Id32, from_bytes for Ident

### DIFF
--- a/canon/Cargo.toml
+++ b/canon/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "canonical"
-version = "0.4.3"
+version = "0.4.4"
 authors = ["Kristoffer Ström <kristoffer@dusk.network>"]
 edition = "2018"
 readme = "README.md"

--- a/canon/src/store.rs
+++ b/canon/src/store.rs
@@ -30,6 +30,13 @@ pub trait Ident:
 {
     /// Takes bytes to produce an identifier
     type Builder: IdBuilder<Self>;
+
+    /// Creates an identifier from a byte slice
+    fn from_bytes(bytes: &[u8]) -> Self {
+        let mut builder = Self::Builder::default();
+        builder.write_bytes(bytes);
+        builder.fin()
+    }
 }
 
 /// Trait to implement writing bytes to an underlying storage


### PR DESCRIPTION
Improvements and helpers implmented while porting rusk-vm