### PR TITLE
Add #[no_mangle] to extern 'C' functions

### DIFF
--- a/canon/Cargo.toml
+++ b/canon/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "canonical"
-version = "0.5.0"
+version = "0.5.1"
 authors = ["Kristoffer Ström <kristoffer@dusk.network>"]
 edition = "2018"
 readme = "README.md"

--- a/canon/src/bridge.rs
+++ b/canon/src/bridge.rs
@@ -115,6 +115,8 @@ where
 
 #[link(wasm_import_module = "canon")]
 extern "C" {
+    #[no_mangle]
     pub fn put(buf: &mut u8, len: usize, ret: &mut u8);
+    #[no_mangle]
     pub fn get(buf: &mut u8);
 }


### PR DESCRIPTION
When used from the binary application "Rusk" the linker is not able to find the symbols of canon's functions, we need to add `#[no_mangle]` for that.