### PR TITLE
Add shields for CI, docs, and github

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # Canonical
 
+![Build Status](https://github.com/dusk-network/canonical/workflows/Continuous%20integration/badge.svg)
+[![Repository](https://img.shields.io/badge/github-canonical-blueviolet?logo=github)](https://github.com/dusk-network/canonical)
+[![Documentation](https://img.shields.io/badge/docs-canonical-blue?logo=rust)](https://docs.rs/canonical/)
+
 Canonical is a specialized serialization library built for merkle trees and suitable for wasm environments.
 
 Its main component is the `Canon` trait, which specifies how the type is encoded to/read from bytes.

--- a/canon/src/lib.rs
+++ b/canon/src/lib.rs
@@ -4,7 +4,14 @@
 //
 // Copyright (c) DUSK NETWORK. All rights reserved.
 
-//! Canonical, a no_std, host-allocating serialization library
+//! ![Build Status](https://github.com/dusk-network/canonical/workflows/Continuous%20integration/badge.svg)
+//! [![Repository](https://img.shields.io/badge/github-canonical-blueviolet?logo=github)](https://github.com/dusk-network/canonical)
+//! [![Documentation](https://img.shields.io/badge/docs-canonical-blue?logo=rust)](https://docs.rs/canonical/)
+
+//! # Canonical
+//!
+//! A no_std, host-allocating serialization library
+
 #![cfg_attr(target_arch = "wasm32", no_std)]
 #![feature(never_type)]
 #![deny(missing_docs)]


### PR DESCRIPTION
-  canonical: Add to lib.rs the shields for CI, docs and github
-  Add to README.md the shields for CI, docs and github

Resolves: #85