### PR TITLE
Use varint for encoding integer values

### DIFF
--- a/canon/Cargo.toml
+++ b/canon/Cargo.toml
@@ -13,6 +13,7 @@ license = "MPL-2.0"
 blake2b_simd = { version = "0.3", default-features = false }
 cfg-if = "1.0.0"
 array-init = "2.0"
+integer-encoding = "3.0"
 
 [dev-dependencies]
 canonical_derive = { path = "../canon_derive", version = "0.6" }

--- a/canon/src/id.rs
+++ b/canon/src/id.rs
@@ -125,7 +125,7 @@ impl Id {
     pub(crate) fn encoded_len_for_payload_len(payload_len: usize) -> usize {
         let actual_payload = core::cmp::min(payload_len, PAYLOAD_BYTES);
         // version, length and the actual payload length
-        1 + 2 + actual_payload
+        1 + (payload_len as u64).encoded_len() + actual_payload
     }
 }
 

--- a/canon/src/store/mod.rs
+++ b/canon/src/store/mod.rs
@@ -71,8 +71,8 @@ impl<'a> Sink<'a> {
 
 /// Struct used in `Canon::decode` to read bytes from a buffer
 pub struct Source<'a> {
-    bytes: &'a [u8],
-    offset: usize,
+    pub(crate) bytes: &'a [u8],
+    pub(crate) offset: usize,
 }
 
 impl<'a> Source<'a> {


### PR DESCRIPTION
I found the "integer-encoding" library most promising and drafted a implementation for Canon for u32.

Since with varint we do not know how many bytes we actually store for each type, I think we need to rewrite the `read_bytes()` method in a way where it doesn't need the number of bytes as input. Since we store the `encoded_len` together with the data, it should be possible to do that.

Let me know what you think!