### PR TITLE
canonical: make library no_std compatible again

### DIFF
--- a/canon/CHANGELOG.md
+++ b/canon/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## [Unreleased]
 
+## [0.6.3] 2021-05-26
+
+### Added
+- Add varint support for `u128` and `i128` by converting them to two `u64`s
+- Add encoding/decoding tests for all integer types
+
+### Changed
+- Change library `integer-encoding` to `dusk-varint`
+
 ## [0.6.2] 2021-05-20
 
 ### Added
@@ -115,7 +124,8 @@
 
 Initial release
 
-[Unreleased]: https://github.com/dusk-network/canonical/compare/canonical-0.6.2...HEAD
+[Unreleased]: https://github.com/dusk-network/canonical/compare/canonical-0.6.3...HEAD
+[0.6.3]: https://github.com/dusk-network/canonical/compare/canonical-0.6.2...canonical-0.6.3
 [0.6.2]: https://github.com/dusk-network/canonical/compare/canonical-0.6.1...canonical-0.6.2
 [0.6.1]: https://github.com/dusk-network/canonical/compare/canonical-0.6.0...canonical-0.6.1
 [0.6.0]: https://github.com/dusk-network/canonical/compare/canonical-0.5.3...canonical-0.6.0

--- a/canon/Cargo.toml
+++ b/canon/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "canonical"
-version = "0.6.2"
+version = "0.6.3"
 authors = ["Kristoffer Ström <kristoffer@dusk.network>"]
 edition = "2018"
 readme = "../README.md"
@@ -13,7 +13,7 @@ license = "MPL-2.0"
 blake2b_simd = { version = "0.3", default-features = false }
 cfg-if = "1.0.0"
 array-init = "2.0"
-integer-encoding = "3.0"
+dusk-varint = "0.1"
 
 [dev-dependencies]
 canonical_derive = { path = "../canon_derive", version = "0.6" }

--- a/canon/src/store/bridge.rs
+++ b/canon/src/store/bridge.rs
@@ -7,7 +7,8 @@
 extern crate alloc;
 
 use crate::canon::CanonError;
-use crate::id::IdHash;
+use crate::id::{Id, IdHash};
+use alloc::vec::Vec;
 
 /// Store usable across ffi-boundraries
 #[derive(Clone, Copy, Default, Debug)]
@@ -45,7 +46,7 @@ impl BridgeStore {
         let mut buf = Vec::with_capacity(len);
         buf.resize_with(len, || 0);
         Self::get(&id.hash(), &mut buf[..])?;
-        Ok(vec)
+        Ok(buf)
     }
 }
 

--- a/canon/src/store/mod.rs
+++ b/canon/src/store/mod.rs
@@ -10,6 +10,7 @@ use core::fmt;
 
 use crate::id::{Id, IdHash};
 use crate::CanonError;
+use alloc::vec::Vec;
 
 cfg_if! {
     if #[cfg(target_arch = "wasm32")] {

--- a/canon/tests/integers.rs
+++ b/canon/tests/integers.rs
@@ -1,0 +1,123 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+//
+// Copyright (c) DUSK NETWORK. All rights reserved.
+
+use canonical::{Canon, Sink, Source};
+
+#[test]
+fn test_u8() {
+    let mut buf = [0u8; 1];
+
+    for i in 0..u8::MAX {
+        let mut sink = Sink::new(&mut buf);
+        i.encode(&mut sink);
+        drop(sink);
+        let mut source = Source::new(&buf);
+        assert_eq!(i, u8::decode(&mut source).unwrap());
+    }
+}
+
+#[test]
+fn test_u16() {
+    let mut buf = [0u8; 3];
+
+    for i in 0..u16::MAX {
+        let mut sink = Sink::new(&mut buf);
+        i.encode(&mut sink);
+        drop(sink);
+        let mut source = Source::new(&buf);
+        assert_eq!(i, u16::decode(&mut source).unwrap());
+    }
+}
+
+#[test]
+fn test_u32() {
+    let mut buf = [0u8; 5];
+
+    let mut i = 0;
+    const STRIDE: u32 = u32::MAX / 1024;
+
+    while i < u32::MAX {
+        i = i.saturating_add(STRIDE);
+
+        let mut sink = Sink::new(&mut buf);
+        i.encode(&mut sink);
+        drop(sink);
+        let mut source = Source::new(&buf);
+        assert_eq!(i, u32::decode(&mut source).unwrap());
+    }
+}
+
+#[test]
+fn test_u64() {
+    let mut buf = [0u8; 10];
+
+    let mut i = 0;
+    const STRIDE: u64 = u64::MAX / 1024;
+
+    while i < u64::MAX {
+        i = i.saturating_add(STRIDE);
+
+        let mut sink = Sink::new(&mut buf);
+        i.encode(&mut sink);
+        drop(sink);
+        let mut source = Source::new(&buf);
+        assert_eq!(i, u64::decode(&mut source).unwrap());
+    }
+}
+
+#[test]
+fn test_u128() {
+    let mut buf = [0u8; 20];
+
+    let mut i = 0;
+    const STRIDE: u128 = u128::MAX / 1024;
+
+    while i < u128::MAX {
+        i = i.saturating_add(STRIDE);
+
+        let mut sink = Sink::new(&mut buf);
+        i.encode(&mut sink);
+        drop(sink);
+        let mut source = Source::new(&buf);
+        assert_eq!(i, u128::decode(&mut source).unwrap());
+    }
+}
+
+#[test]
+fn test_i64() {
+    let mut buf = [0u8; 10];
+
+    let mut i = i64::MIN;
+    const STRIDE: i64 = i64::MAX / 1024;
+
+    while i < i64::MAX {
+        i = i.saturating_add(STRIDE);
+
+        let mut sink = Sink::new(&mut buf);
+        i.encode(&mut sink);
+        drop(sink);
+        let mut source = Source::new(&buf);
+        assert_eq!(i, i64::decode(&mut source).unwrap());
+    }
+}
+
+#[test]
+fn test_i128() {
+    let mut buf = [0u8; 20];
+
+    let mut i = i128::MIN;
+    const STRIDE: i128 = i128::MAX / 1024;
+
+    while i < i128::MAX {
+        i = i.saturating_add(STRIDE);
+
+        let mut sink = Sink::new(&mut buf);
+        i.encode(&mut sink);
+        drop(sink);
+        let mut source = Source::new(&buf);
+        assert_eq!(i, i128::decode(&mut source).unwrap());
+    }
+}


### PR DESCRIPTION
- Change library `integer-encoding` to `dusk-varint`
- Add varint support for `u128` and `i128` by converting them to two `u64`s
- Add encoding/decoding tests for all integer types

fixes #101 